### PR TITLE
Update runtime/sdk version and change runtime from .Sdk to .Platform

### DIFF
--- a/com.gitlab.cutecom.cutecom.json
+++ b/com.gitlab.cutecom.cutecom.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "com.gitlab.cutecom.cutecom",
-	"runtime": "org.kde.Sdk",
-	"runtime-version": "5.15-21.08",
+	"runtime": "org.kde.Platform",
+	"runtime-version": "5.15-22.08",
 	"sdk": "org.kde.Sdk",
 	"command": "cutecom",
 	"rename-icon": "cutecom",

--- a/com.gitlab.cutecom.cutecom.json
+++ b/com.gitlab.cutecom.cutecom.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "com.gitlab.cutecom.cutecom",
 	"runtime": "org.kde.Platform",
-	"runtime-version": "5.15-22.08",
+	"runtime-version": "5.15-23.08",
 	"sdk": "org.kde.Sdk",
 	"command": "cutecom",
 	"rename-icon": "cutecom",


### PR DESCRIPTION
I learned just now that the cutecom flatpak uses `org.kde.Sdk` as runtime. And it is not immediately clear as of why it is used. Therefore, I tested with `org.kde.Platform` and it seems to work just fine. Maybe, this change can save some disk space for the users.